### PR TITLE
feat: support per-monitor module layout

### DIFF
--- a/config.jsonc
+++ b/config.jsonc
@@ -28,6 +28,21 @@
         "custom/power"
     ],
 
+    // Per-output module layout override (key = output name, e.g. eDP-1 / DP-2 / HDMI-A-1).
+    // Omitted modules-* keys inherit the global defaults; an explicit [] empties that side.
+    // "*" matches every output not listed by name.
+    // "monitors": {
+    //     "eDP-1": {
+    //         "modules-left": ["workspaces", "layout", "window"],
+    //         "modules-right": ["tray", "clock#time", "custom/power"]
+    //     },
+    //     "DP-2": {
+    //         "modules-left": ["workspaces", "window"],
+    //         "modules-right": ["clock#time"]
+    //     },
+    //     "*": { "modules-left": ["workspaces"] }
+    // },
+
     "workspaces": {
         "hide-empty": true,
         // "pinned": [1, 2],

--- a/mangobar.c
+++ b/mangobar.c
@@ -437,6 +437,7 @@ typedef struct {
   char net_ifname[64];
   double net_rx_kbps, net_tx_kbps;
   bool redraw;
+  MangoMonitorCfg *mcfg; // per-output module layout override (NULL = global)
   bool overview_mode; // true when active_tags == [0]
   Hotspot hotspots[MAX_HOTSPOTS];
   int hotspot_count;
@@ -1389,6 +1390,25 @@ static void draw_bar(Bar *bar) {
   IPC_LOG("[draw] %s enter\n", bar->name);
   g_draw_scale = bar->scale > 0 ? (uint32_t)bar->scale : 1;
   g_draw_font = font_for_scale(bar->scale);
+  // Per-output module layout override, falling back to the global order.
+  const int *right_order = bar->mcfg && bar->mcfg->right_set
+                               ? bar->mcfg->right_order
+                               : g_cfg.right_order;
+  int right_count = bar->mcfg && bar->mcfg->right_set
+                        ? bar->mcfg->right_count
+                        : g_cfg.right_count;
+  const int *center_order = bar->mcfg && bar->mcfg->center_set
+                                ? bar->mcfg->center_order
+                                : g_cfg.center_order;
+  int center_count = bar->mcfg && bar->mcfg->center_set
+                         ? bar->mcfg->center_count
+                         : g_cfg.center_count;
+  const int *left_order = bar->mcfg && bar->mcfg->left_set
+                              ? bar->mcfg->left_order
+                              : g_cfg.left_order;
+  int left_count = bar->mcfg && bar->mcfg->left_set
+                       ? bar->mcfg->left_count
+                       : g_cfg.left_count;
   int fd = allocate_shm_file(bar->bufsize);
   if (fd < 0) {
     IPC_LOG("[draw] %s shm alloc FAILED\n", bar->name);
@@ -1452,7 +1472,7 @@ static void draw_bar(Bar *bar) {
   char right_texts[MAX_MODULE_ENTRIES][256];
   char right_names[MAX_MODULE_ENTRIES][96];
   int rtext_n = 0, rname_n = 0;
-  int right_n = build_module_entries(bar, g_cfg.right_order, g_cfg.right_count,
+  int right_n = build_module_entries(bar, right_order, right_count,
                                      right_ents, MAX_MODULE_ENTRIES,
                                      right_texts, right_names, &rtext_n,
                                      &rname_n);
@@ -1476,7 +1496,7 @@ static void draw_bar(Bar *bar) {
   char center_names[MAX_MODULE_ENTRIES][96];
   int ctext_n = 0, cname_n = 0;
   int center_n =
-      build_module_entries(bar, g_cfg.center_order, g_cfg.center_count,
+      build_module_entries(bar, center_order, center_count,
                            center_ents, MAX_MODULE_ENTRIES, center_texts,
                            center_names, &ctext_n, &cname_n);
   uint32_t center_cw = 0;
@@ -1517,7 +1537,7 @@ static void draw_bar(Bar *bar) {
   char scratch_texts[MAX_MODULE_ENTRIES][256];
   char scratch_names[MAX_MODULE_ENTRIES][96];
   int stext_n = 0, sname_n = 0;
-  int left_n = build_module_entries(bar, g_cfg.left_order, g_cfg.left_count,
+  int left_n = build_module_entries(bar, left_order, left_count,
                                     scratch, MAX_MODULE_ENTRIES,
                                     scratch_texts, scratch_names, &stext_n,
                                     &sname_n);
@@ -1737,11 +1757,32 @@ static const struct wl_output_listener wl_output_listener = {
     .scale = wl_output_scale,
 };
 
+// Resolve the per-output module layout for an output name. Exact name match
+// wins; otherwise a "*" (or empty-name) entry acts as the fallback; otherwise
+// NULL means "use the global modules-left/center/right defaults".
+static MangoMonitorCfg *monitor_cfg_for_name(const char *name) {
+  if (!name)
+    name = "";
+  for (int i = 0; i < g_cfg.monitor_count; i++) {
+    if (g_cfg.monitors[i].output[0] &&
+        strcmp(g_cfg.monitors[i].output, name) == 0)
+      return &g_cfg.monitors[i];
+  }
+  for (int i = 0; i < g_cfg.monitor_count; i++) {
+    if (g_cfg.monitors[i].output[0] == '\0' ||
+        strcmp(g_cfg.monitors[i].output, "*") == 0)
+      return &g_cfg.monitors[i];
+  }
+  return NULL;
+}
+
 static void output_name_handler(void *data, struct zxdg_output_v1 *xdg_output,
                                 const char *name) {
   Bar *bar = data;
   free(bar->name);
   bar->name = strdup(name);
+  bar->mcfg = monitor_cfg_for_name(name);
+  bar->redraw = true; // layout may change once the output name is known
 }
 
 static void output_logical_position(void *data,

--- a/rtconfig.c
+++ b/rtconfig.c
@@ -432,6 +432,57 @@ static void parse_modules(cJSON *root) {
                     &g_cfg.right_count);
 }
 
+// Parse one monitor override object: { "modules-left": [...], ... }. Keys that
+// are absent inherit the global lists; a present (possibly empty) list wins.
+static void parse_monitor_override(cJSON *obj, MangoMonitorCfg *mc) {
+  mc->left_count = mc->center_count = mc->right_count = 0;
+  mc->left_set = mc->center_set = mc->right_set = false;
+  if (cJSON_GetObjectItemCaseSensitive(obj, "modules-left")) {
+    parse_module_list(obj, "modules-left", mc->left_order, &mc->left_count);
+    mc->left_set = true;
+  }
+  if (cJSON_GetObjectItemCaseSensitive(obj, "modules-center")) {
+    parse_module_list(obj, "modules-center", mc->center_order,
+                      &mc->center_count);
+    mc->center_set = true;
+  }
+  if (cJSON_GetObjectItemCaseSensitive(obj, "modules-right")) {
+    parse_module_list(obj, "modules-right", mc->right_order, &mc->right_count);
+    mc->right_set = true;
+  }
+}
+
+// Parse the top-level "monitors" block. Accepts either an object keyed by
+// output name ("eDP-1": {...}) or an array of { "output": ..., ... } items.
+static void parse_monitors(cJSON *root) {
+  g_cfg.monitor_count = 0;
+  cJSON *mon = cJSON_GetObjectItemCaseSensitive(root, "monitors");
+  if (cJSON_IsArray(mon)) {
+    cJSON *item;
+    cJSON_ArrayForEach(item, mon) {
+      if (!cJSON_IsObject(item) || g_cfg.monitor_count >= MANGOBAR_MAX_MONITORS)
+        continue;
+      MangoMonitorCfg *mc = &g_cfg.monitors[g_cfg.monitor_count++];
+      memset(mc, 0, sizeof(*mc));
+      cJSON *out = cJSON_GetObjectItemCaseSensitive(item, "output");
+      if (cJSON_IsString(out))
+        snprintf(mc->output, sizeof(mc->output), "%s", out->valuestring);
+      parse_monitor_override(item, mc);
+    }
+  } else if (cJSON_IsObject(mon)) {
+    cJSON *item;
+    cJSON_ArrayForEach(item, mon) {
+      if (!cJSON_IsObject(item) || !item->string ||
+          g_cfg.monitor_count >= MANGOBAR_MAX_MONITORS)
+        continue;
+      MangoMonitorCfg *mc = &g_cfg.monitors[g_cfg.monitor_count++];
+      memset(mc, 0, sizeof(*mc));
+      snprintf(mc->output, sizeof(mc->output), "%s", item->string);
+      parse_monitor_override(item, mc);
+    }
+  }
+}
+
 static void parse_module_configs(cJSON *root) {
   cJSON *m;
 
@@ -869,6 +920,7 @@ int mango_config_parse(const char *jsonc) {
     cfg_set(g_cfg.css_path, sizeof(g_cfg.css_path), v->valuestring);
 
   parse_modules(root);
+  parse_monitors(root);
   parse_module_configs(root);
   cJSON_Delete(root);
   return 0;

--- a/rtconfig.h
+++ b/rtconfig.h
@@ -13,6 +13,7 @@
 #define MANGOBAR_MAX_ALTS 128
 #define MANGOBAR_MAX_ICONS 64
 #define MANGOBAR_MAX_LENS 128
+#define MANGOBAR_MAX_MONITORS 16
 
 enum MangoModule {
   M_NONE = 0,
@@ -81,6 +82,23 @@ typedef struct {
   int max_length;  /* 0 = unlimited */
 } MangoMaxLen;
 
+// Per-output module layout override. Mirrors the global modules-left/center/
+// right lists, but scoped to one output name ("*" or "" = fallback). The
+// *_set flags distinguish "not configured" (inherit global) from an explicit
+// empty list "[]" (show nothing on that side).
+typedef struct {
+  char output[64]; // output name to match; "*" or "" = fallback
+  int left_order[MANGOBAR_MAX_MODULES];
+  int center_order[MANGOBAR_MAX_MODULES];
+  int right_order[MANGOBAR_MAX_MODULES];
+  int left_count;
+  int center_count;
+  int right_count;
+  bool left_set;
+  bool center_set;
+  bool right_set;
+} MangoMonitorCfg;
+
 typedef struct {
   int bar_height;
   int buffer_scale;
@@ -138,6 +156,8 @@ typedef struct {
   int alt_count;
   MangoMaxLen max_lens[MANGOBAR_MAX_LENS];
   int max_len_count;
+  MangoMonitorCfg monitors[MANGOBAR_MAX_MONITORS];
+  int monitor_count;
   char css_path[512];
 } MangoConfig;
 


### PR DESCRIPTION
Add a top-level 'monitors' config block keyed by output name, so each output can override modules-left/center/right. Omitted keys inherit the global defaults, an explicit [] empties that side, and '*' matches any output not listed by name.

The output name arrives asynchronously via xdg-output, so the match is resolved in output_name_handler and the bar is marked for redraw.