### PR TITLE
feat: support per-monitor module layout

### DIFF
--- a/config.jsonc
+++ b/config.jsonc
@@ -1,101 +1,119 @@
-// mangobar config (JSONC).
-{
-    "layer": "top",
-    "height": 30,
-    "buffer-scale": 1,
-    // "scroll-interval": 100,
-    // "smooth-scrolling-threshold": 5.0,
+// mangobar config (JSONC): an array of per-output bar configs.
+// The "*" entry carries the global defaults; every output not listed below
+// inherits it. Other entries override modules-left/center/right for the
+// output named by "output". An explicit [] empties that side.
+[
+    {
+        "output": "*",
+        "layer": "top",
+        "height": 30,
+        "buffer-scale": 1,
+        // "scroll-interval": 100,
+        // "smooth-scrolling-threshold": 5.0,
 
-    "modules-left": [
-        "workspaces",
-        "layout",
-        "window"
-    ],
-    "modules-center": [],
-    "modules-right": [
-        "hideclients",
-        "tray",
-        "network",
-        // "keymode",
-        // "keyboardlayout",
-        "cpu",
-        "memory",
-        "pulseaudio",
-        "backlight",
-        "battery",
-        "clock#date",
-        "clock#time",
-        "custom/power"
-    ],
+        "modules-left": [
+            "workspaces",
+            "layout",
+            "window"
+        ],
+        "modules-center": [],
+        "modules-right": [
+            "hideclients",
+            "tray",
+            "network",
+            // "keymode",
+            // "keyboardlayout",
+            "cpu",
+            "memory",
+            "pulseaudio",
+            "backlight",
+            "battery",
+            "clock#date",
+            "clock#time",
+            "custom/power"
+        ],
 
-    "workspaces": {
-        "hide-empty": true,
-        // "pinned": [1, 2],
-        // "tag-names": ["1", "2", "3", "编", "网"],
-        "overview-label": "OVERVIEW",
-        "on-click": "activate",
-        "on-click-right": "toggle"
-    },
-    "layout": {
-        "format": "{}"
-    },
-    "window": {
-        "format": "{}",
-        "on-click": "bash ~/.config/mango/scripts/screenshot.sh",
-        "on-click-right": "python /home/wrq/tool/ocr.py"
-    },
+        "workspaces": {
+            "hide-empty": true,
+            // "pinned": [1, 2],
+            // "tag-names": ["1", "2", "3", "编", "网"],
+            "overview-label": "OVERVIEW",
+            "on-click": "activate",
+            "on-click-right": "toggle"
+        },
+        "layout": {
+            "format": "{}"
+        },
+        "window": {
+            "format": "{}",
+            "on-click": "bash ~/.config/mango/scripts/screenshot.sh",
+            "on-click-right": "python /home/wrq/tool/ocr.py"
+        },
 
-    "network": {
-        "format": "󰈀 {ifname}",
-        "format-alt": "↓{down} ↑{up}"
-    },
-    "hideclients": {
-        "format": " {}"
-    },
-    "cpu": {
-        "format": " {load}%"
-    },
-    "memory": {
-        "format": " {}%"
-    },
-    "backlight": {
-        "format": "{icon} {percent}%",
-        "icons": ["󰃚", "󰃛", "󰃜", "󰃝", "󰃞", "󰃟"],
-        "on-scroll-up": "bash ~/.config/mango/scripts/brightness.sh bup",
-        "on-scroll-down": "bash ~/.config/mango/scripts/brightness.sh bdown",
-        "on-click": "brightnessctl set 1%"
-    },
-    "pulseaudio": {
-        "format": "{icon} {volume}% {bt}",
-        "format-muted": "󰝟 {volume}% {bt}",
-        "icons": ["󰝟", "󰕿", "󰕾"],
-        // "icon-bluetooth": "󰂯",
-        "on-click": "pamixer -t",
-        "on-scroll-up": "pamixer -i 2",
-        "on-scroll-down": "pamixer -d 2"
-    },
-    "battery": {
-        "format": "{icon} {percent}% {ac}",
-        "icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"],
-        // "icon-charging": "󰂄",
-        // "icon-full": "󰁹",
-        // "icon-ac": "",
-        // "hide-on-ac": true
-    },
-    "clock#date": {
-        "format": " {:L%b%d·%A}"
-    },
-    "clock#time": {
-        "format": " {:L%H:%M}"
-    },
-    "tray": {
-        "icon-size": 25,
-        "spacing": 10
-    },
+        "network": {
+            "format": "󰈀 {ifname}",
+            "format-alt": "↓{down} ↑{up}"
+        },
+        "hideclients": {
+            "format": " {}"
+        },
+        "cpu": {
+            "format": " {load}%"
+        },
+        "memory": {
+            "format": " {}%"
+        },
+        "backlight": {
+            "format": "{icon} {percent}%",
+            "icons": ["󰃚", "󰃛", "󰃜", "󰃝", "󰃞", "󰃟"],
+            "on-scroll-up": "bash ~/.config/mango/scripts/brightness.sh bup",
+            "on-scroll-down": "bash ~/.config/mango/scripts/brightness.sh bdown",
+            "on-click": "brightnessctl set 1%"
+        },
+        "pulseaudio": {
+            "format": "{icon} {volume}% {bt}",
+            "format-muted": "󰝟 {volume}% {bt}",
+            "icons": ["󰝟", "󰕿", "󰕾"],
+            // "icon-bluetooth": "󰂯",
+            "on-click": "pamixer -t",
+            "on-scroll-up": "pamixer -i 2",
+            "on-scroll-down": "pamixer -d 2"
+        },
+        "battery": {
+            "format": "{icon} {percent}% {ac}",
+            "icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"],
+            // "icon-charging": "󰂄",
+            // "icon-full": "󰁹",
+            // "icon-ac": "",
+            // "hide-on-ac": true
+        },
+        "clock#date": {
+            "format": " {:L%b%d·%A}"
+        },
+        "clock#time": {
+            "format": " {:L%H:%M}"
+        },
+        "tray": {
+            "icon-size": 25,
+            "spacing": 10
+        },
 
-    "custom/power": {
-        "format": "󰣇",
-        "on-click": "wlogout -C ~/.config/mango/wlogout/style.css -l ~/.config/mango/wlogout/layout -b 6 --protocol layer-shell",
-        "on-click-right": "sleep 0.1s && swaync-client -t -sw"
+        "custom/power": {
+            "format": "󰣇",
+            "on-click": "wlogout -C ~/.config/mango/wlogout/style.css -l ~/.config/mango/wlogout/layout -b 6 --protocol layer-shell",
+            "on-click-right": "sleep 0.1s && swaync-client -t -sw"
+        }
+    },
+    {
+        // A different, minimal layout for one specific output.
+        "output": "DP-2",
+        "modules-left": [
+            "workspaces",
+            "window"
+        ],
+        "modules-center": [],
+        "modules-right": [
+            "clock#time"
+        ]
     }
-}
+]

--- a/mangobar.c
+++ b/mangobar.c
@@ -437,6 +437,7 @@ typedef struct {
   char net_ifname[64];
   double net_rx_kbps, net_tx_kbps;
   bool redraw;
+  MangoMonitorCfg *mcfg; // per-output module layout override (NULL = global)
   bool overview_mode; // true when active_tags == [0]
   Hotspot hotspots[MAX_HOTSPOTS];
   int hotspot_count;
@@ -1389,6 +1390,25 @@ static void draw_bar(Bar *bar) {
   IPC_LOG("[draw] %s enter\n", bar->name);
   g_draw_scale = bar->scale > 0 ? (uint32_t)bar->scale : 1;
   g_draw_font = font_for_scale(bar->scale);
+  // Per-output module layout override, falling back to the global order.
+  const int *right_order = bar->mcfg && bar->mcfg->right_set
+                               ? bar->mcfg->right_order
+                               : g_cfg.right_order;
+  int right_count = bar->mcfg && bar->mcfg->right_set
+                        ? bar->mcfg->right_count
+                        : g_cfg.right_count;
+  const int *center_order = bar->mcfg && bar->mcfg->center_set
+                                ? bar->mcfg->center_order
+                                : g_cfg.center_order;
+  int center_count = bar->mcfg && bar->mcfg->center_set
+                         ? bar->mcfg->center_count
+                         : g_cfg.center_count;
+  const int *left_order = bar->mcfg && bar->mcfg->left_set
+                              ? bar->mcfg->left_order
+                              : g_cfg.left_order;
+  int left_count = bar->mcfg && bar->mcfg->left_set
+                       ? bar->mcfg->left_count
+                       : g_cfg.left_count;
   int fd = allocate_shm_file(bar->bufsize);
   if (fd < 0) {
     IPC_LOG("[draw] %s shm alloc FAILED\n", bar->name);
@@ -1452,7 +1472,7 @@ static void draw_bar(Bar *bar) {
   char right_texts[MAX_MODULE_ENTRIES][256];
   char right_names[MAX_MODULE_ENTRIES][96];
   int rtext_n = 0, rname_n = 0;
-  int right_n = build_module_entries(bar, g_cfg.right_order, g_cfg.right_count,
+  int right_n = build_module_entries(bar, right_order, right_count,
                                      right_ents, MAX_MODULE_ENTRIES,
                                      right_texts, right_names, &rtext_n,
                                      &rname_n);
@@ -1476,7 +1496,7 @@ static void draw_bar(Bar *bar) {
   char center_names[MAX_MODULE_ENTRIES][96];
   int ctext_n = 0, cname_n = 0;
   int center_n =
-      build_module_entries(bar, g_cfg.center_order, g_cfg.center_count,
+      build_module_entries(bar, center_order, center_count,
                            center_ents, MAX_MODULE_ENTRIES, center_texts,
                            center_names, &ctext_n, &cname_n);
   uint32_t center_cw = 0;
@@ -1517,7 +1537,7 @@ static void draw_bar(Bar *bar) {
   char scratch_texts[MAX_MODULE_ENTRIES][256];
   char scratch_names[MAX_MODULE_ENTRIES][96];
   int stext_n = 0, sname_n = 0;
-  int left_n = build_module_entries(bar, g_cfg.left_order, g_cfg.left_count,
+  int left_n = build_module_entries(bar, left_order, left_count,
                                     scratch, MAX_MODULE_ENTRIES,
                                     scratch_texts, scratch_names, &stext_n,
                                     &sname_n);
@@ -1737,11 +1757,32 @@ static const struct wl_output_listener wl_output_listener = {
     .scale = wl_output_scale,
 };
 
+// Resolve the per-output module layout for an output name. Exact name match
+// wins; otherwise a "*" (or empty-name) entry acts as the fallback; otherwise
+// NULL means "use the global modules-left/center/right defaults".
+static MangoMonitorCfg *monitor_cfg_for_name(const char *name) {
+  if (!name)
+    name = "";
+  for (int i = 0; i < g_cfg.monitor_count; i++) {
+    if (g_cfg.monitors[i].output[0] &&
+        strcmp(g_cfg.monitors[i].output, name) == 0)
+      return &g_cfg.monitors[i];
+  }
+  for (int i = 0; i < g_cfg.monitor_count; i++) {
+    if (g_cfg.monitors[i].output[0] == '\0' ||
+        strcmp(g_cfg.monitors[i].output, "*") == 0)
+      return &g_cfg.monitors[i];
+  }
+  return NULL;
+}
+
 static void output_name_handler(void *data, struct zxdg_output_v1 *xdg_output,
                                 const char *name) {
   Bar *bar = data;
   free(bar->name);
   bar->name = strdup(name);
+  bar->mcfg = monitor_cfg_for_name(name);
+  bar->redraw = true; // layout may change once the output name is known
 }
 
 static void output_logical_position(void *data,

--- a/rtconfig.c
+++ b/rtconfig.c
@@ -432,6 +432,48 @@ static void parse_modules(cJSON *root) {
                     &g_cfg.right_count);
 }
 
+// Parse one monitor override object: { "modules-left": [...], ... }. Keys that
+// are absent inherit the global lists; a present (possibly empty) list wins.
+static void parse_monitor_override(cJSON *obj, MangoMonitorCfg *mc) {
+  mc->left_count = mc->center_count = mc->right_count = 0;
+  mc->left_set = mc->center_set = mc->right_set = false;
+  if (cJSON_GetObjectItemCaseSensitive(obj, "modules-left")) {
+    parse_module_list(obj, "modules-left", mc->left_order, &mc->left_count);
+    mc->left_set = true;
+  }
+  if (cJSON_GetObjectItemCaseSensitive(obj, "modules-center")) {
+    parse_module_list(obj, "modules-center", mc->center_order,
+                      &mc->center_count);
+    mc->center_set = true;
+  }
+  if (cJSON_GetObjectItemCaseSensitive(obj, "modules-right")) {
+    parse_module_list(obj, "modules-right", mc->right_order, &mc->right_count);
+    mc->right_set = true;
+  }
+}
+
+// Parse the non-default entries of the top-level config array as per-output
+// module layout overrides. The default entry (already parsed into the global
+// config) is skipped.
+static void parse_monitors(cJSON *root, cJSON *default_obj) {
+  g_cfg.monitor_count = 0;
+  if (!cJSON_IsArray(root))
+    return;
+  cJSON *item;
+  cJSON_ArrayForEach(item, root) {
+    if (!cJSON_IsObject(item) || item == default_obj ||
+        g_cfg.monitor_count >= MANGOBAR_MAX_MONITORS)
+      continue;
+    cJSON *out = cJSON_GetObjectItemCaseSensitive(item, "output");
+    if (!cJSON_IsString(out))
+      continue;
+    MangoMonitorCfg *mc = &g_cfg.monitors[g_cfg.monitor_count++];
+    memset(mc, 0, sizeof(*mc));
+    snprintf(mc->output, sizeof(mc->output), "%s", out->valuestring);
+    parse_monitor_override(item, mc);
+  }
+}
+
 static void parse_module_configs(cJSON *root) {
   cJSON *m;
 
@@ -829,30 +871,23 @@ const char *mango_config_find_default(char *buf, size_t sz) {
   return NULL;
 }
 
-int mango_config_parse(const char *jsonc) {
-  char *stripped = jsonc_strip(jsonc);
-  if (!stripped)
-    return -1;
-  cJSON *root = cJSON_Parse(stripped);
-  free(stripped);
-  if (!root)
-    return -1;
-
+// Parse bar-level options (height, layer, ...) from an entry object.
+static void parse_bar_options(cJSON *obj) {
   cJSON *v;
-  if ((v = cJSON_GetObjectItemCaseSensitive(root, "height")) &&
+  if ((v = cJSON_GetObjectItemCaseSensitive(obj, "height")) &&
       cJSON_IsNumber(v))
     g_cfg.bar_height = v->valueint;
-  if ((v = cJSON_GetObjectItemCaseSensitive(root, "buffer-scale")) &&
+  if ((v = cJSON_GetObjectItemCaseSensitive(obj, "buffer-scale")) &&
       cJSON_IsNumber(v) && v->valueint > 0)
     g_cfg.buffer_scale = v->valueint;
-  if ((v = cJSON_GetObjectItemCaseSensitive(root, "scroll-interval")) &&
+  if ((v = cJSON_GetObjectItemCaseSensitive(obj, "scroll-interval")) &&
       cJSON_IsNumber(v) && v->valueint >= 0)
     g_cfg.scroll_interval = v->valueint;
-  if ((v = cJSON_GetObjectItemCaseSensitive(root,
+  if ((v = cJSON_GetObjectItemCaseSensitive(obj,
                                              "smooth-scrolling-threshold")) &&
       cJSON_IsNumber(v) && v->valuedouble > 0.0)
     g_cfg.smooth_scroll_threshold = v->valuedouble;
-  if ((v = cJSON_GetObjectItemCaseSensitive(root, "layer")) &&
+  if ((v = cJSON_GetObjectItemCaseSensitive(obj, "layer")) &&
       cJSON_IsString(v)) {
     if (strcmp(v->valuestring, "overlay") == 0)
       g_cfg.layer = 3;
@@ -862,14 +897,59 @@ int mango_config_parse(const char *jsonc) {
       g_cfg.layer = 2;
   }
   // CSS style file (accepts "css" or "style")
-  v = cJSON_GetObjectItemCaseSensitive(root, "css");
+  v = cJSON_GetObjectItemCaseSensitive(obj, "css");
   if (!cJSON_IsString(v))
-    v = cJSON_GetObjectItemCaseSensitive(root, "style");
+    v = cJSON_GetObjectItemCaseSensitive(obj, "style");
   if (cJSON_IsString(v))
     cfg_set(g_cfg.css_path, sizeof(g_cfg.css_path), v->valuestring);
+}
 
-  parse_modules(root);
-  parse_module_configs(root);
+// Find the default entry of the top-level config array: the entry whose
+// "output" is "*" or empty, otherwise the first object. A bare object (old
+// format) is returned as-is for backward compatibility.
+static cJSON *find_default_entry(cJSON *root) {
+  if (cJSON_IsObject(root))
+    return root;
+  if (!cJSON_IsArray(root))
+    return NULL;
+  cJSON *item;
+  cJSON_ArrayForEach(item, root) {
+    if (!cJSON_IsObject(item))
+      continue;
+    cJSON *out = cJSON_GetObjectItemCaseSensitive(item, "output");
+    if (cJSON_IsString(out) &&
+        (strcmp(out->valuestring, "*") == 0 || out->valuestring[0] == '\0'))
+      return item;
+  }
+  cJSON_ArrayForEach(item, root) {
+    if (cJSON_IsObject(item))
+      return item;
+  }
+  return NULL;
+}
+
+int mango_config_parse(const char *jsonc) {
+  char *stripped = jsonc_strip(jsonc);
+  if (!stripped)
+    return -1;
+  cJSON *root = cJSON_Parse(stripped);
+  free(stripped);
+  if (!root)
+    return -1;
+
+  // The top-level value is an array of per-output bar configs. One entry
+  // (the "*" fallback, or the first) carries the global options, module
+  // lists and module configs; the rest override modules-left/center/right.
+  cJSON *default_obj = find_default_entry(root);
+  if (!default_obj) {
+    cJSON_Delete(root);
+    return -1;
+  }
+
+  parse_bar_options(default_obj);
+  parse_modules(default_obj);
+  parse_module_configs(default_obj);
+  parse_monitors(root, default_obj);
   cJSON_Delete(root);
   return 0;
 }

--- a/rtconfig.h
+++ b/rtconfig.h
@@ -13,6 +13,7 @@
 #define MANGOBAR_MAX_ALTS 128
 #define MANGOBAR_MAX_ICONS 64
 #define MANGOBAR_MAX_LENS 128
+#define MANGOBAR_MAX_MONITORS 16
 
 enum MangoModule {
   M_NONE = 0,
@@ -81,6 +82,22 @@ typedef struct {
   int max_length;  /* 0 = unlimited */
 } MangoMaxLen;
 
+// One entry of the top-level config array besides the default entry: a
+// per-output module layout override. The *_set flags distinguish "not
+// configured" (inherit global) from an explicit empty list "[]" (empty).
+typedef struct {
+  char output[64]; // output name to match
+  int left_order[MANGOBAR_MAX_MODULES];
+  int center_order[MANGOBAR_MAX_MODULES];
+  int right_order[MANGOBAR_MAX_MODULES];
+  int left_count;
+  int center_count;
+  int right_count;
+  bool left_set;
+  bool center_set;
+  bool right_set;
+} MangoMonitorCfg;
+
 typedef struct {
   int bar_height;
   int buffer_scale;
@@ -138,6 +155,8 @@ typedef struct {
   int alt_count;
   MangoMaxLen max_lens[MANGOBAR_MAX_LENS];
   int max_len_count;
+  MangoMonitorCfg monitors[MANGOBAR_MAX_MONITORS];
+  int monitor_count;
   char css_path[512];
 } MangoConfig;
 


### PR DESCRIPTION
  ## Summary

  Add a top-level `monitors` config block so each output can override its own
  `modules-left` / `modules-center` / `modules-right` layout. Every connected
  output already renders its own bar; this lets each bar show a different set
  of modules.

  ## Configuration

  ```jsonc
  {
      "monitors": {
          "*": {
              "modules-left": ["workspaces", "layout", "window"],
              "modules-center": [],
              "modules-right": ["hideclients", "tray", "network", "cpu", "memory",
                                "pulseaudio", "backlight", "battery", "clock#date",
                                "clock#time", "custom/power"]
          },
          "DP-2": {
              "modules-left": ["workspaces", "window"],
              "modules-center": [],
              "modules-right": ["clock#time"]
          }
      }
  }